### PR TITLE
Copy, not clone

### DIFF
--- a/II - MAGISTRALE/II - [02GRSOV] Programmazione di Sistema/Esami Rust/2023-07-07.md
+++ b/II - MAGISTRALE/II - [02GRSOV] Programmazione di Sistema/Esami Rust/2023-07-07.md
@@ -38,7 +38,7 @@ Per quanto riguarda il codice:
 - viene stampato `20 10 20`
 - vengono rilasciate le variabili sullo stack, questo include i puntatori realizzati che a loro volta smettono di puntare ai relativi valori nel heap, che verranno anche questi rilasciati non avendo più alcun puntatore che li referenzi
 
-**Nota**: in questo caso `i` non viene posseduto dal puntatore in quanto implementa il tratto `clone`, dunque non avviene la presa di possesso ma viene in automatico copiato il valore e ricaricato nel heap.
+**Nota**: in questo caso `i` non viene posseduto dal puntatore in quanto implementa il tratto `Copy`, dunque non avviene la presa di possesso ma viene in automatico copiato il valore e ricaricato nel heap.
 
 </details>
 


### PR DESCRIPTION
`Clone::clone` non viene mai chiamato in automatico